### PR TITLE
Fix slider error when section is disabled

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -55,6 +55,14 @@ scrollToTopButton.addEventListener('click', () => {
 
 document.addEventListener("DOMContentLoaded", function () {
     const slides = document.querySelectorAll(".slide");
+    const nextBtn = document.getElementById("next");
+    const prevBtn = document.getElementById("prev");
+
+    // Si no existen elementos para el slider, no ejecutar la lógica
+    if (slides.length === 0 || !nextBtn || !prevBtn) {
+        return;
+    }
+
     let currentIndex = 0;
     let autoPlayInterval; // Variable para el intervalo de autoplay
 
@@ -82,13 +90,13 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Eventos de los botones manuales
-    document.getElementById("next").addEventListener("click", function () {
+    nextBtn.addEventListener("click", function () {
         nextSlide();
         stopAutoPlay(); // Detiene el autoplay cuando el usuario interactúa
         startAutoPlay(); // Reinicia el autoplay
     });
 
-    document.getElementById("prev").addEventListener("click", function () {
+    prevBtn.addEventListener("click", function () {
         prevSlide();
         stopAutoPlay(); // Detiene el autoplay cuando el usuario interactúa
         startAutoPlay(); // Reinicia el autoplay


### PR DESCRIPTION
### **User description**
## Summary
- avoid JS errors when the recommendation slider is commented out

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68731cfd1cc083209cca2abedb14ff62


___

### **PR Type**
Bug fix


___

### **Description**
- Add null checks for slider elements to prevent JavaScript errors

- Guard slider initialization when DOM elements are missing

- Improve error handling for recommendation slider functionality


___

### **Changes diagram**

```mermaid
flowchart LR
  A["DOM Content Loaded"] --> B["Check slider elements exist"]
  B --> C{"slides.length > 0 && nextBtn && prevBtn?"}
  C -->|No| D["Return early - skip slider logic"]
  C -->|Yes| E["Initialize slider functionality"]
  E --> F["Add event listeners to buttons"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scripts.js</strong><dd><code>Guard slider initialization with element validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/scripts.js

<li>Add null checks for slider elements before initialization<br> <li> Cache button references to avoid repeated DOM queries<br> <li> Return early if required slider elements are missing<br> <li> Replace direct getElementById calls with cached references


</details>


  </td>
  <td><a href="https://github.com/PamelaOrmeno/portafolio-profesional/pull/1/files#diff-60d1c73f64a9165c32e0c42d3a3a6bec1dcc4a466fa5136ddfbe217bbb58d418">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>